### PR TITLE
検索時に大文字と小文字を無視するようにした。

### DIFF
--- a/app/controllers/binders_controller.rb
+++ b/app/controllers/binders_controller.rb
@@ -73,7 +73,7 @@ class BindersController < ApplicationController
     @queries = params[:q].split(/\s+/)
     @binders = Binder.all
     @queries.each do |query|
-      @binders = @binders.where('title LIKE ? OR description LIKE ?', "%#{query}%", "%#{query}%")
+      @binders = @binders.where('title ILIKE ? OR description ILIKE ?', "%#{query}%", "%#{query}%")
     end
     @binders = @binders.order('updated_at DESC').page params[:page]
 


### PR DESCRIPTION
PostgreSQLの`ILIKE`を使用して、検索時にアルファベットの大文字と小文字の違いを無視するようにした。